### PR TITLE
added constant parsing, pi, and e, fixed ASSERT_SIM macro

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -34,6 +34,13 @@ struct func_s funcs[FUNCS_NUM]={
   {log10, "log10"}
 };
 
+
+struct const_s consts[CONSTS_NUM]={
+  {M_E, "e"},
+  {M_PI, "pi"}
+};
+
+
 void assign(struct op_s * op, char opch){
   int i;
   for(i = 0; i<OPS_NUM; i++){
@@ -61,6 +68,22 @@ unsigned int next_token(const char *expr, token * res){
       strcpy(res->data.func.name, funcs[i].name);
 
       idx += strlen(funcs[i].name);
+      return idx;
+    }
+  }
+
+
+  /*look for constants*/
+  for(i = 0; i<CONSTS_NUM; i++){
+    if (strstr(expr, consts[i].name) == expr){
+      d_print(consts[i].name);
+
+      res->type = CONST;
+
+      res->data.n = consts[i].n;
+      strcpy(res->data.cst.name, consts[i].name);
+
+      idx += strlen(consts[i].name);
       return idx;
     }
   }
@@ -156,6 +179,7 @@ expr parse(const char * in){
     
     switch(tok->type){
       case NUM:
+      case CONST:
       case VARX:
       case VARY:
         queue[++queue_last] = tok;
@@ -231,7 +255,7 @@ double eval(const expr e, double x, double y){
   unsigned int i;
   for(i = 0; i<e.size; i++){
     token * t = e.parsed[i];
-    if (t->type == NUM){
+    if (t->type == NUM || t->type == CONST){
       stack[++stack_top] = t->data.n;
     } else if(t->type == VARX){
       stack[++stack_top] = x;
@@ -269,6 +293,7 @@ int check_expr(const expr e){
     token * t = e.parsed[i];
     switch(t->type){
       case NUM:
+      case CONST:
       case VARX:
       case VARY:
         stack++; break;
@@ -311,6 +336,8 @@ void delete_expr(expr * d){
 void prnt_token(token tok){
   if(tok.type == NUM){
     printf("{NUM %.2f}", tok.data.n);
+  } else if(tok.type == CONST){
+    printf("{CONST %s}", tok.data.cst.name);
   } else if(tok.type == OP){
     printf("{OP %c}", tok.data.op.op);
   } else if(tok.type == VARX){

--- a/src/parser.h
+++ b/src/parser.h
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <math.h>
 
+#define CONSTS_NUM 2
 #define OPS_NUM 9
 #define FUNCS_NUM 10
 
@@ -31,8 +32,14 @@ struct func_s {
   char name[8];
 };
 
+struct const_s {
+  double n;
+  char name[8];
+};
+
 enum token_t{
   NUM,
+  CONST,
   VARX,
   VARY,
   OP,
@@ -46,6 +53,7 @@ enum token_t{
 typedef struct tok_t{
   union {
     double n;
+    struct const_s cst;
     struct op_s op;
     struct func_s func;
   } data;

--- a/test/test.c
+++ b/test/test.c
@@ -6,7 +6,7 @@
 
 #define EPSILON 0.0001
 
-#define ASSERT_SIM(x,y) if(fabs((x)-(y))>=EPSILON){printf("Expected value:%f\n  Actual value: %f\n"); assert(0);}
+#define ASSERT_SIM(x,y) if(fabs((x)-(y))>=EPSILON){printf("Expected value: %f\n  Actual value: %f\n",y,x); assert(0);}
 
 double random_(){
   double x = rand() / (RAND_MAX + 1.);
@@ -50,9 +50,43 @@ void parse1(){
 }
 
 
+double c1(double x){return M_PI;}
+double c2(double x){return M_PI + x;}
+double c3(double x){return sin(M_PI + x);}
+double c4(double x){return M_PI + sin(x);}
+
+void parse_const(){
+  unsigned int i;
+  expr e;
+  double x;
+
+  e = parse("pi");
+  for(i = 0; i<1000; i++){
+    x = random_();
+    ASSERT_SIM(eval(e, x, 0), c1(x));
+  }
+
+  e = parse("pi + x");
+  for(i = 0; i<1000; i++){
+    x = random_();
+    ASSERT_SIM(eval(e, x, 0), c2(x));
+  }
+
+  e = parse("sin(pi + x)");
+  for(i = 0; i<1000; i++){
+    x = random_();
+    ASSERT_SIM(eval(e, x, 0), c3(x));
+  }
+
+  e = parse("pi + sin(x)");
+  for(i = 0; i<1000; i++){
+    x = random_();
+    ASSERT_SIM(eval(e, x, 0), c4(x));
+  }
+}
+
 int main(){
   parse1();
-
-
+  parse_const();
 }
 


### PR DESCRIPTION
In my opinion, a program like termplot has to have constants, such as π and e, so we can plot `sin(x+pi/2)` easily.

I don't expect all the changes are good since I didn't read the code thoroughly, just copied, pasted, and edited as I go, though a few quick tests did show the graphs are correct.

If the naming, order, or anything doesn't fit or simply is wrong, please let me know, I will be happy to make adjustments and corrections.
