### PR TITLE
added delete, clear, and refresh commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ And it will work. Termplot can also plot implicit functions, like
 #TODO
 
 * Zooming just in one axis
-* Deleting plots
 * Replacing plots
 * Write out to files
 * Read from commandline/stdin

--- a/src/command.c
+++ b/src/command.c
@@ -1,6 +1,25 @@
+#include <errno.h>
 #include "command.h"
 
 void nothing(char * arg){;}
+
+void delete_plot(char * arg){
+  long int i;
+  char * endptr;
+  errno = 0;
+  i = strtol(arg, &endptr, 10);
+  if (errno == 0 && arg != endptr) {
+    delete_function(i);
+  }
+}
+
+void clear_plotter(char * arg __attribute__((unused))){
+  clean_plotter();
+}
+
+void refresh_plotter(char * arg __attribute__((unused))){
+  replot_functions();
+}
 
 void quit(char * arg){
   options.quit = 1;
@@ -11,6 +30,9 @@ struct{
   void (*func)(char * arg);
 } cmds[] = {{"nop", nothing},
             {"plot", add_plot},
+            {"delete", delete_plot},
+            {"clear", clear_plotter},
+            {"refresh", refresh_plotter},
             {"quit", quit},
             {"q", quit}
            };

--- a/src/plot.h
+++ b/src/plot.h
@@ -28,6 +28,8 @@ void add_plot(char * cmd);
 
 void draw_axis();
 
+void delete_function(unsigned int i);
+
 void init_plotter();
 void clean_plotter();
 


### PR DESCRIPTION
There a few things I want to bring up.

The location of functions for commands, the `add_plot` is placed in `plot.c` but I am not sure if that's completely right and that's why I put `delete_plot` in `command.c`. I think function in `plot.c` should only do in a scope of plotting, not with arguments regarding user's input command, that is `char * arg`, it should be split into two, just like `delete_plot` and `delete_function`.

The `clear_plotter` and `refresh_plotter`, I decide to create them, even there is no issues if I just put the `clean_plotter` and `replot_functions` into the `cmds` array. Reason is kind of same as above and I want the type signatures do match.

Again, anything you don't see fit, let me know. Not sure if we really need a refresh command, but it seems many programs in terminal actually provide a redraw functionality, hm, `redraw` is shorter.
