### PR TITLE
fix error with string initialisation in plot.c  & linker updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ endif
 WARNINGS = -Wall -Wextra -Werror -Wshadow -Wstrict-prototypes -Wpointer-arith \
 					 -Wcast-qual
 OPT_FLAGS = -O3 -flto -ffast-math
-CFLAGS = $(WARNINGS) -Werror -std=c99 -pedantic
-LFLAGS = -lm
+CFLAGS = $(WARNINGS) -Werror -std=c23 -pedantic
+LFLAGS = -lm -z muldefs
 TEST_DIR = test/
 SRC_DIR = src/
 UI_SRC_DIR = $(SRC_DIR)ui/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ WARNINGS = -Wall -Wextra -Werror -Wshadow -Wstrict-prototypes -Wpointer-arith \
 					 -Wcast-qual
 OPT_FLAGS = -O3 -flto -ffast-math
 CFLAGS = $(WARNINGS) -Werror -std=c23 -pedantic
-LFLAGS = -lm -z muldefs
+LFLAGS = -lm
 TEST_DIR = test/
 SRC_DIR = src/
 UI_SRC_DIR = $(SRC_DIR)ui/

--- a/src/command.c
+++ b/src/command.c
@@ -1,7 +1,10 @@
 #include "command.h"
 
-#include <stdlib.h>
 #include <string.h>
+
+command_history_t command_history;
+char command[CMD_SIZE] = {0};
+unsigned int cursor = 0;
 
 void nothing(__attribute__((unused)) char* arg) {
 }

--- a/src/command.h
+++ b/src/command.h
@@ -1,5 +1,4 @@
-#ifndef COMMAND
-#define COMMAND
+#pragma once
 #include <ctype.h>
 
 #include "debug.h"
@@ -23,5 +22,3 @@ unsigned int cursor;
 
 void run_command(void);
 void input_command(void);
-
-#endif // COMMAND

--- a/src/command.h
+++ b/src/command.h
@@ -10,15 +10,17 @@
 #define CMD_HIST 10
 #define CMD_SIZE 500
 
-struct {
+typedef struct command_history_t {
   // Kind of bounded stack.
   char* commands[CMD_HIST];
   unsigned int last;
   unsigned int first;
-} command_history;
+} command_history_t;
 
-char command[CMD_SIZE];
-unsigned int cursor;
+extern command_history_t command_history;
+
+extern char command[CMD_SIZE];
+extern unsigned int cursor;
 
 void run_command(void);
 void input_command(void);

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,6 +1,7 @@
 #include "debug.h"
 
 FILE * dbg;
+int debug_enabled = 0;
 
 void start_debug(void) {
   if (debug_enabled) {

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/debug.h
+++ b/src/debug.h
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int debug_enabled;
+extern int debug_enabled;
 
 void start_debug(void);
 void d_print(const char * format, ...);

--- a/src/options.c
+++ b/src/options.c
@@ -1,5 +1,7 @@
 #include "options.h"
 
+struct options_t options;
+
 void init_structs(void) {
   options.x_center = 0.0;
   options.y_center = 0.0;

--- a/src/options.h
+++ b/src/options.h
@@ -1,5 +1,4 @@
-#ifndef OPTIONS
-#define OPTIONS
+#pragma once
 
 #include <stdbool.h>
 #include "structs.h"
@@ -7,5 +6,3 @@
 
 struct options_t options;
 void init_structs(void);
-
-#endif // OPTIONS

--- a/src/options.h
+++ b/src/options.h
@@ -4,5 +4,5 @@
 #include "structs.h"
 
 
-struct options_t options;
+extern struct options_t options;
 void init_structs(void);

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,5 +1,4 @@
-#ifndef PARSER
-#define PARSER
+#pragma once
 
 #include <ctype.h>
 #include <math.h>
@@ -84,5 +83,3 @@ void delete_expr(expr*  d);
 
 void debug_print(token** s, int sz);
 void debug_print_token(token tok);
-
-#endif

--- a/src/plot.c
+++ b/src/plot.c
@@ -3,6 +3,8 @@
 #define MAX(x,y) ((x)>(y)?(x):(y))
 #define MIN(x,y) ((x)<(y)?(x):(y))
 
+function functions[MAX_FUNCTIONS];
+
 void fill_plot(struct function* new) {
   new->valid = 0;
   if (new->f.size > 0) {

--- a/src/plot.c
+++ b/src/plot.c
@@ -53,7 +53,7 @@ void replot_functions(void) {
 }
 
 void plot_function(expr e, int index) {
-  static char c[1] = "o";
+  static char c[2] = "o";
 
   int height = options.height;
   int width = options.width;
@@ -146,7 +146,7 @@ bool cut(const expr* e1, const expr* e2,
 
 void plot_implicit(expr e1, expr e2, int index) {
 
-  static char c[1] = "o";
+  static char c[2] = "o";
 
   int height = options.height;
   int width = options.width;

--- a/src/plot.h
+++ b/src/plot.h
@@ -13,12 +13,14 @@
 
 enum { EXPLICIT, IMPLICIT };
 
-struct function {
+typedef struct function {
     expr f;
     expr g;
     unsigned char type;
     unsigned char valid;
-} functions[MAX_FUNCTIONS];
+} function;
+
+extern function functions[MAX_FUNCTIONS];
 
 
 double test_interval(const expr* e1, const expr* e2, 

--- a/src/plot.h
+++ b/src/plot.h
@@ -1,5 +1,4 @@
-#ifndef PLOT
-#define PLOT
+#pragma once
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,4 +41,3 @@ void init_plotter(void);
 void clean_plotter(void);
 
 
-#endif

--- a/src/structs.h
+++ b/src/structs.h
@@ -1,5 +1,4 @@
-#ifndef STRUCTS
-#define STRUCTS
+#pragma once
 
 struct buffer_entry {
   char* buf;
@@ -22,5 +21,3 @@ struct options_t {
   bool show_info;
   double cpu_time_draw; 
 };
-
-#endif

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,5 +1,4 @@
-#ifndef UI
-#define UI
+#pragma once
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -20,5 +19,3 @@ void wcprintf(int y, int x, unsigned int fg_color, unsigned int bg_color,
               char* fmt, ...);
 void update_cmd(void);
 void update_ui(void);
-
-#endif

--- a/src/ui/ui_ncurses.c
+++ b/src/ui/ui_ncurses.c
@@ -2,6 +2,9 @@
 
 #include <stdlib.h>
 
+WINDOW* win = NULL;
+bool curses_started = false;
+
 void start_ui(void) {
   if (curses_started) {
     refresh();

--- a/src/ui/ui_ncurses.h
+++ b/src/ui/ui_ncurses.h
@@ -1,5 +1,4 @@
-#ifndef UI_NCURSES
-#define UI_NCURSES
+#pragma once
 
 #include <ncurses.h>
 
@@ -23,5 +22,3 @@ void finish_paint(int cmd_length, unsigned int cursor, struct options_t opts);
 void term_clear(void);
 void term_refresh(void);
 bool should_redraw(void);
-
-#endif

--- a/src/ui/ui_ncurses.h
+++ b/src/ui/ui_ncurses.h
@@ -9,8 +9,8 @@
 #define FG_WHITE BW
 #define BG_BLACK BW
 
-WINDOW* win;
-bool curses_started;
+extern WINDOW* win;
+extern bool curses_started;
 
 void start_ui(void);
 void end_ui(void);

--- a/src/ui/ui_termbox.h
+++ b/src/ui/ui_termbox.h
@@ -1,5 +1,4 @@
-#ifndef UI_TERMBOX
-#define UI_TERMBOX
+#pragma once
 
 #include <termbox.h>
 #include <stdbool.h>
@@ -28,4 +27,3 @@ void term_clear(void);
 void term_refresh(void);
 bool should_redraw(void);
 
-#endif


### PR DESCRIPTION
In the functions `plot_function` and `plot_implicit`, the string initialisation `static char c[1] = "o"` causes an error as the array of size 1 does not provide space for the NUL-terminator. Thus the fix is to increase the array size to 2: `static char c[2] = "o"`.

In addition, I updated the header files to use the `#pragma once` directive for easier include management.

Finally, I added the linker flag `-z muldefs` to allow multiple definitions with arise from the globally defined variables in the header files. This should maybe be redesigned at some point. Also, I updated the C standard to c23.

Cool project! :)